### PR TITLE
support go.1.22.2 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ git clone https://github.com/MadhavJivrajani/gse.git && cd gse
 go build .
 # optional
 mv ./gse /usr/local/bin
+if permission denied then use export path instead 
+export PATH=$PATH:$PWD/gse
 ```
 ### Run `gse`
 An example program and config file can be found [here](./example).
 #### Compile the program
 ```sh
-go build -o gophercon main.go
+go build -o ./example/gophercon ./example/main.go
 ```
 #### Running `gse`
 Before actually running `gse`, make sure you have prometheus running whose config matches the `prometheus` part of the config provided to `gse`. The config I used and passed to a locally running `prometheus` was:

--- a/example/test.yaml
+++ b/example/test.yaml
@@ -1,4 +1,4 @@
-path: "./example/gophercon"
+path: "GOMAXPROCS=2 ./example/gophercon"
 prometheus:
   endpoint: metrics
   port: 8080

--- a/pkg/exporter/scheduler_metrics.go
+++ b/pkg/exporter/scheduler_metrics.go
@@ -32,6 +32,7 @@ type SchedulerMetrics struct {
 	SpinningThreads      prometheus.Gauge
 	IdleThreads          prometheus.Gauge
 	GlobalRunQueueLength prometheus.Gauge
+	NeedsSpinningThreads prometheus.Gauge
 	// the length of this slice will
 	// be equal to the value of GOMAXPORCS.
 	LocalRunQueueLengths []prometheus.Gauge
@@ -63,6 +64,12 @@ func NewSchedulerMetrics() *SchedulerMetrics {
 				Help: "Idle Threads",
 			},
 		),
+		NeedsSpinningThreads: promauto.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "needs_spinning_threads",
+				Help: "Needs Spinning Threads",
+			},
+		),
 		GlobalRunQueueLength: promauto.NewGauge(
 			prometheus.GaugeOpts{
 				Name: "global_runqueue_length",
@@ -90,7 +97,9 @@ func (sm *SchedulerMetrics) UpdateMetricsFromTrace(st *sched.SchedTrace) {
 	sm.Threads.Set(float64(st.Threads))
 	sm.SpinningThreads.Set(float64(st.SpinningThreads))
 	sm.IdleThreads.Set(float64(st.IdleThreads))
+	sm.NeedsSpinningThreads.Set(float64(st.NeedsSpinningThreads))
 	sm.GlobalRunQueueLength.Set(float64(st.GlobalRunQueueLength))
+
 	for i := 0; i < len(sm.LocalRunQueueLengths); i++ {
 		sm.LocalRunQueueLengths[i].Set(float64(st.LocalRunQueueLengths[i]))
 	}

--- a/pkg/exporter/scheduler_metrics.go
+++ b/pkg/exporter/scheduler_metrics.go
@@ -32,7 +32,7 @@ type SchedulerMetrics struct {
 	SpinningThreads      prometheus.Gauge
 	IdleThreads          prometheus.Gauge
 	GlobalRunQueueLength prometheus.Gauge
-	NeedsSpinningThreads prometheus.Gauge
+	NeedSpinningThreads  prometheus.Gauge
 	// the length of this slice will
 	// be equal to the value of GOMAXPORCS.
 	LocalRunQueueLengths []prometheus.Gauge
@@ -64,7 +64,7 @@ func NewSchedulerMetrics() *SchedulerMetrics {
 				Help: "Idle Threads",
 			},
 		),
-		NeedsSpinningThreads: promauto.NewGauge(
+		NeedSpinningThreads: promauto.NewGauge(
 			prometheus.GaugeOpts{
 				Name: "needs_spinning_threads",
 				Help: "Needs Spinning Threads",
@@ -97,7 +97,7 @@ func (sm *SchedulerMetrics) UpdateMetricsFromTrace(st *sched.SchedTrace) {
 	sm.Threads.Set(float64(st.Threads))
 	sm.SpinningThreads.Set(float64(st.SpinningThreads))
 	sm.IdleThreads.Set(float64(st.IdleThreads))
-	sm.NeedsSpinningThreads.Set(float64(st.NeedsSpinningThreads))
+	sm.NeedSpinningThreads.Set(float64(st.NeedSpinningThreads))
 	sm.GlobalRunQueueLength.Set(float64(st.GlobalRunQueueLength))
 
 	for i := 0; i < len(sm.LocalRunQueueLengths); i++ {

--- a/pkg/sched/sched_trace.go
+++ b/pkg/sched/sched_trace.go
@@ -32,7 +32,7 @@ type SchedTrace struct {
 	SpinningThreads      int
 	IdleThreads          int
 	GlobalRunQueueLength int
-	NeedsSpinningThreads int
+	NeedSpinningThreads  int
 	// the length of this slice will
 	// be equal to the value of GOMAXPORCS.
 	LocalRunQueueLengths []int
@@ -43,9 +43,10 @@ type SchedTrace struct {
 // of length equal to GOMAXPROCS.
 func NewSchedTrace() *SchedTrace {
 	n := runtime.GOMAXPROCS(-1)
-	log.Printf("GOMAXPROCS: %d", n)
+	log.Printf("GOMAXPROCS: %d\n", n)
 	return &SchedTrace{
 		LocalRunQueueLengths: make([]int, n),
+		Gomaxprocs:           n,
 	}
 }
 
@@ -56,11 +57,10 @@ func (st *SchedTrace) UpdateSchedTraceFromRawTrace(rawTrace string) {
 	// this is a lot of hacky code to get the information out of a scheduler trace
 	// line that looks as follows with GOMAXPROCS being 8:
 	// SCHED 0ms: gomaxprocs=8 idleprocs=6 threads=5 spinningthreads=1 needspinning=1 idlethreads=2 runqueue=0 [0 0 0 0 0 0 0 0]
-	st.Gomaxprocs = getValueFromKVPair(split[2])
 	st.Idleprocs = getValueFromKVPair(split[3])
 	st.Threads = getValueFromKVPair(split[4])
 	st.SpinningThreads = getValueFromKVPair(split[5])
-	st.NeedsSpinningThreads = getValueFromKVPair(split[6])
+	st.NeedSpinningThreads = getValueFromKVPair(split[6])
 	st.IdleThreads = getValueFromKVPair(split[7])
 	st.GlobalRunQueueLength = getValueFromKVPair(split[8])
 

--- a/pkg/sched/sched_trace.go
+++ b/pkg/sched/sched_trace.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sched
 
 import (
+	"log"
 	"runtime"
 	"strconv"
 	"strings"
@@ -31,6 +32,7 @@ type SchedTrace struct {
 	SpinningThreads      int
 	IdleThreads          int
 	GlobalRunQueueLength int
+	NeedsSpinningThreads int
 	// the length of this slice will
 	// be equal to the value of GOMAXPORCS.
 	LocalRunQueueLengths []int
@@ -41,6 +43,7 @@ type SchedTrace struct {
 // of length equal to GOMAXPROCS.
 func NewSchedTrace() *SchedTrace {
 	n := runtime.GOMAXPROCS(-1)
+	log.Printf("GOMAXPROCS: %d", n)
 	return &SchedTrace{
 		LocalRunQueueLengths: make([]int, n),
 	}
@@ -50,20 +53,20 @@ func NewSchedTrace() *SchedTrace {
 // scheduler trace.
 func (st *SchedTrace) UpdateSchedTraceFromRawTrace(rawTrace string) {
 	split := strings.Split(rawTrace, " ")
-
 	// this is a lot of hacky code to get the information out of a scheduler trace
 	// line that looks as follows with GOMAXPROCS being 8:
-	// SCHED 0ms: gomaxprocs=8 idleprocs=6 threads=5 spinningthreads=1 idlethreads=2 runqueue=0 [0 0 0 0 0 0 0 0]
+	// SCHED 0ms: gomaxprocs=8 idleprocs=6 threads=5 spinningthreads=1 needspinning=1 idlethreads=2 runqueue=0 [0 0 0 0 0 0 0 0]
 	st.Gomaxprocs = getValueFromKVPair(split[2])
 	st.Idleprocs = getValueFromKVPair(split[3])
 	st.Threads = getValueFromKVPair(split[4])
 	st.SpinningThreads = getValueFromKVPair(split[5])
-	st.IdleThreads = getValueFromKVPair(split[6])
-	st.GlobalRunQueueLength = getValueFromKVPair(split[7])
+	st.NeedsSpinningThreads = getValueFromKVPair(split[6])
+	st.IdleThreads = getValueFromKVPair(split[7])
+	st.GlobalRunQueueLength = getValueFromKVPair(split[8])
 
-	st.LocalRunQueueLengths[0] = toInt(split[8][1:])
-	for i := 1; i < runtime.GOMAXPROCS(-1); i++ {
-		st.LocalRunQueueLengths[i] = toInt(split[8+i])
+	st.LocalRunQueueLengths[0] = toInt(split[9][1:])
+	for i := 1; i < st.Gomaxprocs; i++ {
+		st.LocalRunQueueLengths[i] = toInt(split[9+i])
 	}
 }
 


### PR DESCRIPTION
After go1.17 shedtrace output has been changed. causing panics and incorrect afterwards metrics.
Added new extra needs spinning metrics and changed indices of further metrics